### PR TITLE
Correct Image URL For Array

### DIFF
--- a/docs/md/Canna_BC_Northern_Lights_Carbon_Free_Footprint_Solar_Electricty_Notes.md
+++ b/docs/md/Canna_BC_Northern_Lights_Carbon_Free_Footprint_Solar_Electricty_Notes.md
@@ -224,7 +224,7 @@ This corresponds to a ( 2.10 - 3.00 ) kilo **Watt** (kW) rated system ( array ) 
 
 **Analysis**. To configure the 4 x 8 array of Solar Panels shown in the example photo requires (32) panels at a cost of $275 each, or $8,800 USD.
 
-![Example Photo](/images/Canna-Solar-32-Panel-Array-8-x-4-w-Dual-Axis-Tracking-Label-640-x-480-px.png)
+![Example Photo](../blob/master/images/Canna-Solar-32-Panel-Array-8-x-4-w-Dual-Axis-Tracking-Label-640-x-480-px.png?raw=true)
 
 Plus, the cost of the Micro-Inverters (MI), the Dual Axis Tracking mechanism, the mount, and the pedastal.
 


### PR DESCRIPTION
Attempting to use a relative path to Master repo where the subject
image ( the stand-alone 8 x 4 Solar Array ) has been uploaded as a blob
in the ‘images’ subdirectory