### PR TITLE
Correct Instruction for Blockquote

### DIFF
--- a/docs/md/Canna_BC_Northern_Lights_Carbon_Free_Footprint_Solar_Electricty_Notes.md
+++ b/docs/md/Canna_BC_Northern_Lights_Carbon_Free_Footprint_Solar_Electricty_Notes.md
@@ -250,15 +250,17 @@ Similarly, throughout the entire year a 1 (kW) rated System of Solar panels ( Ar
 
 ##======================
 
-###Quoting Text in Blocks ( Blockquote )
+###Quoting Text in Blocks ( Blockquote ) Using Git Hub Flavored Markdown
 
 >When quoting text in blocks ( Blockquote ) using GitHub Flavored Markdown (.md) ...
 
 >Simply place a "greater than" symbol in front of your 2nd line of text, as follows:
 
-**Git Hub Flavored Markdown**
+\>As you can see, the usage of the "greater than" symbol in this case yields an indented 2nd line of text with a corresponding "thick pipe".
 
->As you can see, the usage of the "greater than" symbol in this case yields an indented 2nd line of text with a corresponding "thick pipe".
+###Indented 2nd Line of Text
+
+>... indented 2nd line of text
 
 ##======================
 

--- a/docs/txt/GIT_Post_FB_Twitter_Solar_BloomBox_Notes_111316.rtf
+++ b/docs/txt/GIT_Post_FB_Twitter_Solar_BloomBox_Notes_111316.rtf
@@ -1,0 +1,32 @@
+{\rtf1\ansi\ansicpg1252\cocoartf1504\cocoasubrtf600
+{\fonttbl\f0\fswiss\fcharset0 Helvetica;\f1\fswiss\fcharset0 ArialMT;}
+{\colortbl;\red255\green255\blue255;\red16\green60\blue192;\red255\green255\blue255;}
+{\*\expandedcolortbl;\csgray\c100000;\cssrgb\c6667\c33333\c80000;\cssrgb\c100000\c100000\c100000;}
+{\info
+{\author Robert Weber}
+{\*\company BS - Bus Admin, MBA; MISM, EJD, Director}
+{\*\copyright Copyright 2016. All rights reserved.}}\margl1440\margr1440\vieww18320\viewh15460\viewkind0
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
+
+\f0\b\fs24 \cf0 BC Northern Lights | BloomBox | Solar Power | Notes\
+====================== 
+\b0 \
+\
+Carbon Free Footprint\
+\
+Full URL: {\field{\*\fldinst{HYPERLINK "https://github.com/rwebaz/CarbonFreeFootprint/blob/master/docs/md/Canna_BC_Northern_Lights_Carbon_Free_Footprint_Solar_Electricty_Notes.md"}}{\fldrslt 
+\f1\fs25\fsmilli12800 \cf2 \cb3 \expnd0\expndtw0\kerning0
+\ul \ulc2 \outl0\strokewidth0 \strokec2 https://github.com/rwebaz/CarbonFreeFootprint/blob/master/docs/md/Canna_BC_Northern_Lights_Carbon_Free_Footprint_Solar_Electricty_Notes.md}}\
+\
+Tiny URL: {\field{\*\fldinst{HYPERLINK "https://medmj.us/CarbonFreeFootprint"}}{\fldrslt https://medmj.us/CarbonFreeFootprint}}\
+\
+Tweet:\
+\
+Solar Panels Six (6) Power #BC Northern Lights Bloombox in #Az. For Analysis C=> {\field{\*\fldinst{HYPERLINK "https://medmj.us/CarbonFreeFootprint"}}{\fldrslt https://medmj.us/CarbonFreeFootprint}} #GotBloomBox? #Please #ReTweet\
+\
+FB:\
+\
+Solar Panels Six (6) Power #BC Northern Lights Bloombox in #Az. For Analysis C=> {\field{\*\fldinst{HYPERLINK "https://medmj.us/CarbonFreeFootprint"}}{\fldrslt https://medmj.us/CarbonFreeFootprint}}\
+\
+
+\b ====================== }


### PR DESCRIPTION
By placing the backslash in front of the now escaped ‘>’ greater than
symbol, the text is rendered normally.