### PR TITLE
Update Gemfile dot lock

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -11,7 +11,7 @@ GEM
     coffee-script (2.4.1)
       coffee-script-source
       execjs
-    coffee-script-source (1.12.2)
+    coffee-script-source (1.11.1)
     colorator (1.1.0)
     ethon (0.10.1)
       ffi (>= 1.3.0)
@@ -179,7 +179,7 @@ GEM
       ffi (>= 0.5.0)
     rouge (1.11.1)
     safe_yaml (1.0.4)
-    sass (3.4.23)
+    sass (3.4.24)
     sawyer (0.8.1)
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)


### PR DESCRIPTION
bundle update GitHub-pages from the /docs subdirectory yields downshift on coffee-script-source dependency from 1.12.2 to 1.11.1; Uptick on sass dependency from 3.4.23 to 3.4.24; using Github-pages ver 138