### PR TITLE
Revert back to relative src

### DIFF
--- a/docs/_includes/page-banner.htm
+++ b/docs/_includes/page-banner.htm
@@ -2,7 +2,7 @@
 	<a href="https://mminail.github.io" title="Click to Visit the Home Page of the MMINAIL" target="_blank">
 		<i>
 			<picture>
-				<img class="img-responsive" src="assets/img/svg/ghp-git-hub-pages-medmjorg-carbon-free-footprint-project-flammarion-got-tree-final-banner-1050-x-173.svg" alt="CFFP Carbon Free Footprint Project Page Banner" />
+				<img class="img-responsive" src="../assets/img/svg/ghp-git-hub-pages-medmjorg-carbon-free-footprint-project-flammarion-got-tree-final-banner-1050-x-173.svg" alt="CFFP Carbon Free Footprint Project Page Banner" />
 			</picture>
 		</i>
 	</a>


### PR DESCRIPTION
Absolute src renders for index page, but not for other pages served
from pages subdirectory